### PR TITLE
'ls /proc' output

### DIFF
--- a/1011_determine_and_configure_hardware_settings.md
+++ b/1011_determine_and_configure_hardware_settings.md
@@ -52,23 +52,23 @@ This is where kernel keeps its data structure and is created in RAM. You can rea
 
 ````
 $ ls /proc/
-1      1249   1451   1565   18069  20346  2426	2765  2926  3175  3317	3537  39    468   4921	53    689   969		 filesystems  misc	     sysvipc
-10     13     146    157    18093  20681  2452	2766  2929  3183  3318	354   397   4694  4934	538   7     97		 fs	      modules	     timer_list
-1039   1321   147    1572   18243  21	  2456	28    2934  3187  34	3541  404   4695  4955	54    737   acpi	 interrupts   mounts	     timer_stats
-10899  13346  148    1576   18274  21021  2462	2841  2936  3191  3450	3550  41    47	  4970	546   74    asound	 iomem	      mtrr	     tty
-10960  13438  14817  158    1859   21139  25	2851  2945  32	  3459	357   42    4720  4982	55    742   buddyinfo	 ioports      net	     uptime
-11     13619  149    16     18617  2129   2592	2852  2947  3202  3466	36    43    4731  4995	551   75    bus		 irq	      pagetypeinfo   version
-11120  13661  15     1613   18781  214	  26	2862  2948  3206  3467	3683  44    4756  5	56    77    cgroups	 kallsyms     partitions     version_signature
-11145  13671  150    1630   1880   215	  27	2865  2952  3208  3469	3699  4484  4774  50	577   8     cmdline	 kcore	      sched_debug    vmallocinfo
-1159   13927  151    1633   1882   2199   2707	2866  2955  3212  3470	37    4495  4795  5008	5806  892   consoles	 keys	      schedstat      vmstat
-1163   14     1512   1634   19	   22	  2708	2884  2957  3225  3474	3710  45    48	  5013	60    9     cpuinfo	 key-users    scsi	     zoneinfo
-1164   14045  1515   1693   19061  2219   2709	2887  2961  3236  3475	3752  4506  4811  5077	61    904   crypto	 kmsg	      self
-1170   14047  152    17     19068  23	  2710	2891  3     324   3477	3761  4529  4821  5082	62    9061  devices	 kpagecount   slabinfo
-1174   14052  153    17173  19069  23055  2711	2895  3047  3261  3517	3778  4558  484   5091	677   915   diskstats	 kpageflags   softirqs
-12     1409   154    1732   19075  2354   2718	29    3093  3284  3522	38    4562  4861  51	678   923   dma		 loadavg      stat
-1231   1444   155    17413  2	   2390   2719	2904  31    3287  3525	3803  46    4891  52	679   939   driver	 locks	      swaps
-1234   1446   156    17751  20	   24	  2723	2908  3132  3298  3528	3823  4622  49	  5202	680   940   execdomains  mdstat       sys
-1236   145    1563   18     2028   2418   2763	2911  3171  33	  3533	3845  4661  4907  525	687   96    fb		 meminfo      sysrq-trigger
+1      1249   1451   1565   18069  20346  2426  2765  2926  3175  3317  3537  39    468   4921  53    689   969          filesystems  misc           sysvipc            
+10     13     146    157    18093  20681  2452  2766  2929  3183  3318  354   397   4694  4934  538   7     97           fs           modules        timer_list         
+1039   1321   147    1572   18243  21     2456  28    2934  3187  34    3541  404   4695  4955  54    737   acpi         interrupts   mounts         timer_stats        
+10899  13346  148    1576   18274  21021  2462  2841  2936  3191  3450  3550  41    47    4970  546   74    asound       iomem        mtrr           tty                
+10960  13438  14817  158    1859   21139  25    2851  2945  32    3459  357   42    4720  4982  55    742   buddyinfo    ioports      net            uptime             
+11     13619  149    16     18617  2129   2592  2852  2947  3202  3466  36    43    4731  4995  551   75    bus          irq          pagetypeinfo   version            
+11120  13661  15     1613   18781  214    26    2862  2948  3206  3467  3683  44    4756  5     56    77    cgroups      kallsyms     partitions     version_signature  
+11145  13671  150    1630   1880   215    27    2865  2952  3208  3469  3699  4484  4774  50    577   8     cmdline      kcore        sched_debug    vmallocinfo        
+1159   13927  151    1633   1882   2199   2707  2866  2955  3212  3470  37    4495  4795  5008  5806  892   consoles     keys         schedstat      vmstat             
+1163   14     1512   1634   19     22     2708  2884  2957  3225  3474  3710  45    48    5013  60    9     cpuinfo      key-users    scsi           zoneinfo           
+1164   14045  1515   1693   19061  2219   2709  2887  2961  3236  3475  3752  4506  4811  5077  61    904   crypto       kmsg         self           
+1170   14047  152    17     19068  23     2710  2891  3     324   3477  3761  4529  4821  5082  62    9061  devices      kpagecount   slabinfo       
+1174   14052  153    17173  19069  23055  2711  2895  3047  3261  3517  3778  4558  484   5091  677   915   diskstats    kpageflags   softirqs       
+12     1409   154    1732   19075  2354   2718  29    3093  3284  3522  38    4562  4861  51    678   923   dma          loadavg      stat           
+1231   1444   155    17413  2      2390   2719  2904  31    3287  3525  3803  46    4891  52    679   939   driver       locks        swaps          
+1234   1446   156    17751  20     24     2723  2908  3132  3298  3528  3823  4622  49    5202  680   940   execdomains  mdstat       sys            
+1236   145    1563   18     2028   2418   2763  2911  3171  33    3533  3845  4661  4907  525   687   96    fb           meminfo      sysrq-trigger
 ````
 
 The numbers are the process IDs! There are also other files like `cpuinfo`, `mounts`, `meminfo`, ...

--- a/1011_determine_and_configure_hardware_settings.md
+++ b/1011_determine_and_configure_hardware_settings.md
@@ -35,22 +35,22 @@ Is really a bus and lets parts of the system communicate with each other. For ex
 ### udev
 Supplies the software with the events and access info of devices and can handle rules.
 
-There are a lot of devices in /dev/ and if you plugin any device, it will have a file in /dev (say /dev/sdb2). **udev** lets you control what will be what in /dev. For example, you can use a rule to force your 8GB flash drive with one specific vendor to be /dev/mybackup all the time or you can tell it to copy all photos to your home directory as soon as your camera is connected.
+There are a lot of devices in `/dev/` and if you plugin any device, it will have a file in `/dev` (say /dev/sdb2). **udev** lets you control what will be what in `/dev`. For example, you can use a rule to force your 8GB flash drive with one specific vendor to be `/dev/mybackup` all the time or you can tell it to copy all photos to your home directory as soon as your camera is connected.
 
 ### sysfs
 The `/sys` directory is where **HAL** keeps its database of everything connected to the system. 
 
-````
+```
 jadi@funlife:~$ ls /sys
 block  bus  class  dev	devices  firmware  fs  hypervisor  kernel  module  power
-````
+```
 
 All block devices are at the `block` and `bus` directory has all the connected PCI, USB, serial, .. devices. Note that here in `sys` we have the devices based on their technology but `/dev/` is abstracted. 
 
 ### proc directory
 This is where kernel keeps its data structure and is created in RAM. You can read and write here (after reboot, the write is gone). 
 
-````
+```
 $ ls /proc/
 1      1249   1451   1565   18069  20346  2426  2765  2926  3175  3317  3537  39    468   4921  53    689   969          filesystems  misc           sysvipc            
 10     13     146    157    18093  20681  2452  2766  2929  3183  3318  354   397   4694  4934  538   7     97           fs           modules        timer_list         
@@ -69,11 +69,11 @@ $ ls /proc/
 1231   1444   155    17413  2      2390   2719  2904  31    3287  3525  3803  46    4891  52    679   939   driver       locks        swaps          
 1234   1446   156    17751  20     24     2723  2908  3132  3298  3528  3823  4622  49    5202  680   940   execdomains  mdstat       sys            
 1236   145    1563   18     2028   2418   2763  2911  3171  33    3533  3845  4661  4907  525   687   96    fb           meminfo      sysrq-trigger
-````
+```
 
 The numbers are the process IDs! There are also other files like `cpuinfo`, `mounts`, `meminfo`, ...
 
-````
+```
 $ cat /proc/cpuinfo 
 processor	: 0
 vendor_id	: GenuineIntel
@@ -126,44 +126,44 @@ clflush size	: 64
 cache_alignment	: 64
 address sizes	: 36 bits physical, 48 bits virtual
 power management:
-````
+```
 
 We can also write here. Since I'm on an IBM Lenovo laptop I can turn my LED on and off by writing here:
 
-````
+```
 root@funlife:/proc/acpi/ibm# echo on > light 
 root@funlife:/proc/acpi/ibm# echo off > light 
-````
+```
 
 One more traditional example is changing the max number of open files per user:
 
-````
+```
 root@funlife:/proc/sys/fs# cat file-max 
 797946
 root@funlife:/proc/sys/fs# echo 1000000 > file-max 
 root@funlife:/proc/sys/fs# cat file-max 
 1000000
-````
+```
 Another very useful directory here, is `/proc/sys/net/ipv4` which controls real time networking configurations. 
 
 > All these changes will be reverted after a boot. You have to write into config files in `/etc/` to make these changes permanent
 
 ### dev
-**udev** controls `/dev/` directory. There are abstracted devices like a hard, is /dev/sda or /dev/hd0 regardless of its brand, model or technology:
+**udev** controls `/dev/` directory. There are abstracted devices like a hard, is `/dev/sda` or `/dev/hd0` regardless of its brand, model or technology:
 
-````
+```
 root@funlife:/dev# ls /dev/sda*
 /dev/sda  /dev/sda1  /dev/sda2  /dev/sda3  /dev/sda5  /dev/sda6
-````
+```
 
 
 ### lsmod, lsusb, lspci
-These commands, list the modules and hardwares on the system. 
+These commands show list of modules and hardwares on the system. 
 
 #### lsmod
 Shows kernel modules.
 
-````
+```
 root@funlife:/dev# lsmod
 Module                  Size  Used by
 pci_stub               12622  1 
@@ -208,38 +208,39 @@ aes_x86_64             17131  1 aesni_intel
 mei_me                 19742  0 
 lrw                    13287  1 aesni_intel
 iwlwifi               183038  1 iwldvm
-````
+```
 
 These are the kernel modules which are loaded. 
 
 If you need to add a module to your kernel (say a new driver for a hardware) or remove it (uninstall a driver) you can use `rmmod` and `modprobe`.
 
-````
+```
 # rmmod iwlwifi 
-````
+```
 
-And this is for installing the modules:
+And this is for installing the module:
 
-````
+```
 # insmod kernel/drivers/net/wireless/lwlwifi.ko
-````
+```
 
-but nobody uses `insmod` because it does not understand dependencies and you need to give it the whole path to the module file. Instead use the `modprobe` command:
+but nobody uses `insmod` because it does not understand dependencies and you need to give it the whole path to the module file. Instead, use the `modprobe` command:
 
-````
+```
 # modprobe iwlwifi
-````
+```
 
-> you can use `-f` switch to FORCE `rmmod` to remove the module even if it is in use
+> you can use `-f` switch to FORCE `rmmod` to remove the module even if it is in use.
 
-If you need to load some modules every time your system boots do one of the following:
-1. add their name to this file `/etc/modules`
-2. add their config files to the `/etc/modprobe.d/`
+If you need to load some modules every time your system boots, do one of the following:
+
+1. add their names to this file `/etc/modules`
+2. add their configs files to the `/etc/modprobe.d/`
 
 #### lspci
 Shows PCI devices that are connected to the computer.
 
-````
+```
 # lspci
 00:00.0 Host bridge: Intel Corporation 2nd Generation Core Processor Family DRAM Controller (rev 09)
 00:02.0 VGA compatible controller: Intel Corporation 2nd Generation Core Processor Family Integrated Graphics Controller (rev 09)
@@ -256,13 +257,13 @@ Shows PCI devices that are connected to the computer.
 00:1f.3 SMBus: Intel Corporation 6 Series/C200 Series Chipset Family SMBus Controller (rev 04)
 03:00.0 Network controller: Intel Corporation Centrino Wireless-N 1000 [Condor Peak]
 0d:00.0 System peripheral: Ricoh Co Ltd MMC/SD Host Controller (rev 07)
-````
+```
 
 
 #### lsusb
 Shows all the USB devices connected to the system.
 
-````
+```
 # lsusb
 Bus 002 Device 003: ID 1c4f:0026 SiGma Micro Keyboard
 Bus 002 Device 002: ID 8087:0024 Intel Corp. Integrated Rate Matching Hub
@@ -272,7 +273,7 @@ Bus 001 Device 004: ID 0a5c:217f Broadcom Corp. BCM2045B (BDC-2.1)
 Bus 001 Device 003: ID 192f:0916 Avago Technologies, Pte. 
 Bus 001 Device 002: ID 8087:0024 Intel Corp. Integrated Rate Matching Hub
 Bus 001 Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub
-````
+```
 
 #### lspcmcia
 Shows available PCMCIA cards on this computer.
@@ -284,9 +285,9 @@ Shows HAL data.
 Shows hardware. Test it!
 
 ## Device UUIDs
-Each device has an ID. If you speak about /dev/sda, you are speaking about the "first hard" but if you want a specific drive to be your /home, you have to use UUID. 
+Each device has an ID. If you speak about `/dev/sda`, you are speaking about the "first hard" but if you want a specific drive to be your `/home`, you have to use UUID. 
 
-````
+```
 root@funlife:/dev# cat /proc/mounts 
 rootfs / rootfs rw 0 0
 sysfs /sys sysfs rw,nosuid,nodev,noexec,relatime 0 0
@@ -295,7 +296,7 @@ udev /dev devtmpfs rw,relatime,size=4014804k,nr_inodes=1003701,mode=755 0 0
 devpts /dev/pts devpts rw,nosuid,noexec,relatime,gid=5,mode=620,ptmxmode=000 0 0
 tmpfs /run tmpfs rw,nosuid,noexec,relatime,size=806028k,mode=755 0 0
 /dev/disk/by-uuid/1651a94e-0b4e-47fb-aca0-f77e05714617 / ext4 rw,relatime,errors=remount-ro,data=ordered 0 0
-````
+```
 
 Every other device has its own ID which can be used to *identify* it. 
 

--- a/1023_manage_shared_libraries.md
+++ b/1023_manage_shared_libraries.md
@@ -25,15 +25,15 @@ When we write a program, we use libraries. For example if you need to read text 
 > Dynamic linking is also called **shared** libraries because all the programs are sharing one library which is separately installed.
 
 ## What libraries I need
-first you should know that libraries are installed in /lib and /lib64 (for 32bit and 64bit libraries). 
+first you should know that libraries are installed in `/lib` and `/lib64` (for 32bit and 64bit libraries). 
 
 #### ldd
-the ````ldd```` command helps you find:
+the `ldd` command helps you find:
 - If a program is dynamically or statically linked
 - What libraries a program needs
 
 lets have a look at two files:
-````
+```
 # ldd /sbin/ldconfig
 	not a dynamic executable
 
@@ -49,9 +49,9 @@ root@funlife:/home/jadi/Downloads# ldd /bin/ls
 	/lib64/ld-linux-x86-64.so.2 (0x00007f61698f8000)
 	libattr.so.1 => /lib/x86_64-linux-gnu/libattr.so.1 (0x00007f6168a6d000)
 	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f616884f000)
-````
+```
 
-As you can see, ````ldd```` tells us that the /sbin/ldconfig is not dynamically linked but shows us the libraries needed by /bin/ls. 
+As you can see, `ldd` tells us that the `/sbin/ldconfig` is not dynamically linked but shows us the libraries needed by `/bin/ls`. 
 
 #### symbolic links for libraries
 If you are writing a program and you use udev functions, you will ask for a library called *libudev.so.1*. But a Linux distro, might call its version of udev library *libudev.so.1.4.0*. How can we solve this problem? with **symbolic links** you will learn more about this in next chapters but for short, a symbolic name is a new name for the same file.
@@ -63,15 +63,15 @@ I will check the same thing on my system. First I'll find where the libudev.so.1
 
 and then will check that file:
 
-	# locate /lib/i386-linux-gnu/libudev.so.1
+	# ls la /lib/i386-linux-gnu/libudev.so.1
 	lrwxrwxrwx 1 root root    16 Nov 13 23:05 /lib/i386-linux-gnu/libudev.so.1 -> libudev.so.1.4.0
 
 As you can see, this is a symbolic link pointing to the version of libudev I have installed (1.4.0) so even if a software says it need libudev.so.1, my system will use its libusdev.so.1.4.0.
 
 #### Dynamic library configs
-As most of other linux tools, dynamic linking is also configured using a text config file. It is located at */etc/ld.so.conf*. On an Ubuntu system it is just points to other config files in /etc/ld.so.conf.d/ but all those lines can be included in the main file too:
+As most of other linux tools, dynamic linking is also configured using a text config file. It is located at */etc/ld.so.conf*. On an Ubuntu system it is just points to other config files in `/etc/ld.so.conf.d/` but all those lines can be included in the main file too:
 
-````
+```
 # cat /etc/ld.so.conf
 include /etc/ld.so.conf.d/*.conf
 
@@ -86,15 +86,15 @@ i386-linux-gnu_GL.conf                  x86_64-linux-gnu.conf                   
 
 root@funlife:/sbin# cat /etc/ld.so.conf.d/x86_64-linux-gnu_GL.conf 
 /usr/lib/x86_64-linux-gnu/mesa
-````
+```
 
-the ````ldconfig```` commands processed all these files to make the loading of libraries faster. This command creates ld.so.cache to locate files that are to be dynamically loaded and linked. 
+the `ldconfig` commands processed all these files to make the loading of libraries faster. This command creates ld.so.cache to locate files that are to be dynamically loaded and linked. 
 
-> if you change the ld.so.conf (or sub-directories) you need to run ldconfig
+> if you change the ld.so.conf (or sub-directories) you need to run `ldconfig`
 
 To close this section lets run ldconfig with the **-p** switch to see what is saved in ld.so.cache:
 
-````
+```
 # ldconfig -p | head
 1358 libs found in cache `/etc/ld.so.cache'
 	libzvbi.so.0 (libc6,x86-64) => /usr/lib/x86_64-linux-gnu/libzvbi.so.0
@@ -105,7 +105,7 @@ To close this section lets run ldconfig with the **-p** switch to see what is sa
 	libzbar.so.0 (libc6,x86-64) => /usr/lib/libzbar.so.0
 ...
 ...
-````
+```
 
 As you can see, this file tells the the kernel that anyone asks for *libzvbi.so.0*, the */usr/lib/x86_64-linux-gnu/libzvbi.so.0* file should be loaded.
 
@@ -121,7 +121,7 @@ For example if you give this command:
 
 	export  LD_LIBRARY_PATH=/usr/lib/myoldlibs:/home/jadi/lpic/libs/
 
-and then run any command, the system will search /usr/lib/myoldlibs and then /home/jadi/lpic/libs/ before going to the main system libraries (defined in ld.so.cache). 
+and then run any command, the system will search `/usr/lib/myoldlibs` and then `/home/jadi/lpic/libs/` before going to the main system libraries (defined in ld.so.cache). 
 .
 .
 

--- a/1023_manage_shared_libraries.md
+++ b/1023_manage_shared_libraries.md
@@ -63,7 +63,7 @@ I will check the same thing on my system. First I'll find where the libudev.so.1
 
 and then will check that file:
 
-	# ls la /lib/i386-linux-gnu/libudev.so.1
+	# ls -la /lib/i386-linux-gnu/libudev.so.1
 	lrwxrwxrwx 1 root root    16 Nov 13 23:05 /lib/i386-linux-gnu/libudev.so.1 -> libudev.so.1.4.0
 
 As you can see, this is a symbolic link pointing to the version of libudev I have installed (1.4.0) so even if a software says it need libudev.so.1, my system will use its libusdev.so.1.4.0.


### PR DESCRIPTION
In my browsers (firefox and chromium) table-like output was messed up.
I added enough spaces between words to rearrange it like a table.
