### PR TITLE
Update 1011_determine_and_configure_hardware_settings.md

### DIFF
--- a/content/1011_determine_and_configure_hardware_settings.md
+++ b/content/1011_determine_and_configure_hardware_settings.md
@@ -65,7 +65,7 @@ Universal Serial Bus. Serial and need fewer connections.
 
 ![USB Interfaces](/images/usb.png)
 
-- 1 (12Mbps), 2 (480Mbps), 3 (20Gbps)
+- 1 (12Mbps), 2 (480Mbps), 3 (PCI.e 2.0 Bus:5Gbps, PCI.e 3.0 Bus:10Gbps, PCI.e 4.0 Bus:20Gbps)
 - A, B, C
 
 ### GPIO


### PR DESCRIPTION
edit USB 3.0 Speed
USB 3.0 first generation, works on PCI.e 2.0 bus and reach up to 5Gbps, on PCI.e 3.0 Gen its bus speed reaches 2x and maximum 10 Gbps, also on PCI.e 4.0 it reaches to 20 Gbps.