### PR TITLE
Updated efi mount point address

### DIFF
--- a/content/1011_determine_and_configure_hardware_settings.md
+++ b/content/1011_determine_and_configure_hardware_settings.md
@@ -40,7 +40,7 @@ Firmware is the software *on* your hardware that runs it; Think of it as a built
 
 
 ![UEFI](/images/uefi.jpeg)
-2. UEFI (Unified Extensible Firmware Interface). Started as EFI in 1998 in Intel. Now the standard. Uses a specific disk partition for boot (EFI System Partition (ESP)) and uses FAT. On Linux it is on /boot and files are .efi. You need to register each bootloader.
+2. UEFI (Unified Extensible Firmware Interface). Started as EFI in 1998 in Intel. Now the standard. Uses a specific disk partition for boot (EFI System Partition (ESP)) and uses FAT. On Linux it is on /boot/efi and files are .efi. You need to register each bootloader.
 
 ## Peripheral Devices
 These are device interfaces.


### PR DESCRIPTION
```
the ESP is typically mounted in the
/boot/efi/ directory, and the boot loader fi les are commonly stored using the .efi
fi lename extension
```
This is copied from `Linux Professional Institute Certification Study Guide Fifth Edition By Christine Bresnahan and Richard Blum`