### PR TITLE
Fix: Some Typo

### DIFF
--- a/content/1051_customize_and_use_the_shell_environment.md
+++ b/content/1051_customize_and_use_the_shell_environment.md
@@ -22,20 +22,20 @@ Candidates should be able to customize shell environments to meet users’ needs
 ### Terms
 
 * .
-* source
-* /etc/bash.bashrc
-* /etc/profile
-* env
-* export
-* set
-* unset
-* ~/.bash\_profile
-* ~/.bash\_login
-* ~/.profile
-* ~/.bashrc
-* ~/.bash\_logout
-* function
-* alias
+* `source`
+* `/etc/bash.bashrc`
+* `/etc/profile`
+* `env`
+* `export`
+* `set`
+* `unset`
+* `~/.bash\_profile`
+* `~/.bash\_login`
+* `~/.profile`
+* `~/.bashrc`
+* `~/.bash\_logout`
+* `function`
+* `alias`
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/dXnsNXV2Y60" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 

--- a/content/1052_customize_or_write_simple_scripts.md
+++ b/content/1052_customize_or_write_simple_scripts.md
@@ -27,15 +27,15 @@ Candidates should be able to customize existing scripts, or write simple new Bas
 
 #### Terms and Utilities
 
-* for
-* while
-* test
-* if
-* read
-* seq
-* exec
-* ||
-* &&
+* `for`
+* `while`
+* `test`
+* `if`
+* `read`
+* `seq`
+* `exec`
+* `||`
+* `&&`
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/0BYkWRf4Yvk" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 

--- a/content/1071_manage_user_and_group_accounts_and_related_system_files.md
+++ b/content/1071_manage_user_and_group_accounts_and_related_system_files.md
@@ -19,19 +19,19 @@ Candidates should be able to add, remove, suspend and change user accounts.
 
 ### Terms and Utilities
 
-* /etc/passwd
-* /etc/shadow
-* /etc/group
-* /etc/skel/
-* chage
-* getent
-* groupadd
-* groupdel
-* groupmod
-* passwd
-* useradd
-* userdel
-* usermod
+* `/etc/passwd`
+* `/etc/shadow`
+* `/etc/group`
+* `/etc/skel/`
+* `chage`
+* `getent`
+* `groupadd`
+* `groupdel`
+* `groupmod`
+* `passwd`
+* `useradd`
+* `userdel`
+* `usermod`
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/xXQ1pw2sAQs" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 

--- a/content/1072_automate_system_administration_tasks_by_scheduling_jobs.md
+++ b/content/1072_automate_system_administration_tasks_by_scheduling_jobs.md
@@ -20,17 +20,17 @@ Candidates should be able to use cron and systemd timers to run jobs at regular 
 
 ### Terms and Utilities
 
-* /etc/cron.{d,daily,hourly,monthly,weekly}/
-* /etc/at.deny
-* /etc/at.allow
-* /etc/crontab
-* /etc/cron.allow
-* /etc/cron.deny
-* /var/spool/cron/
-* crontab
-* at
-* atq
-* atrm
+* `/etc/cron.{d,daily,hourly,monthly,weekly}/`
+* `/etc/at.deny`
+* `/etc/at.allow`
+* `/etc/crontab`
+* `/etc/cron.allow`
+* `/etc/cron.deny`
+* `/var/spool/cron/`
+* `crontab`
+* `at`
+* `atq`
+* `atrm`
 * systemctl
 * systemd-run
 

--- a/content/1081_maintain_system_time.md
+++ b/content/1081_maintain_system_time.md
@@ -16,23 +16,23 @@ Candidates should be able to properly maintain the system time and synchronize t
 * Set the system date and time.
 * Set the hardware clock to the correct time in UTC.
 * Configure the correct timezone.
-* Basic NTP configuration using ntpd and chrony..
-* Knowledge of using the pool.ntp.org service.
-* Awareness of the ntpq command.
+* Basic NTP configuration using `ntpd` and `chrony` ..
+* Knowledge of using the `pool.ntp.org` service.
+* Awareness of the `ntpq` command.
 
 ### Terms and Utilities
 
-* /usr/share/zoneinfo/
-* /etc/timezone
-* /etc/localtime
-* /etc/ntp.conf
-* /etc/chrony.conf
-* date
-* hwclock
-* ntpd
-* ntpdate
-* chronyc
-* pool.ntp.org
+* `/usr/share/zoneinfo/`
+* `/etc/timezone`
+* `/etc/localtime`
+* `/etc/ntp.conf`
+* `/etc/chrony.conf`
+* `date`
+* `hwclock`
+* `ntpd`
+* `ntpdate`
+* `chronyc`
+* `pool.ntp.org`
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/RhH-2I1dBjA" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
@@ -40,7 +40,7 @@ Candidates should be able to properly maintain the system time and synchronize t
 
 There is a clock in your computer; a hardware clock on your motherboard! It has its own battery and keeps the time even when the computer is off. When the system boots, the OS reads this **hardware time** and it sets it's own **system time** based on the hardware clock and uses this clock whenever it needs to know the time.
 
-Hardware clock can be the set on localtime (the time shown on your clock whenever you are) or UTC time (standard time). The `hwclock` can be used to show the time based on the hwtime. See how it works based on the hardware time even after we DO CHANGE the system time:
+Hardware clock can be the set on localtime (the time shown on your clock wherever you are) or UTC time (standard time). The `hwclock` can be used to show the time based on the hwtime. See how it works based on the hardware time even after we DO CHANGE the system time:
 
 ```
 $ date
@@ -67,11 +67,11 @@ The previous commands sets the hardware clock on that specific date and tell it 
 # hwclock -u -w
 ```
 
-Here, `-w` tells the hwclock to set the hardware time based on the current system time and `-u` tells the hwclock that we are using the UTC. This also sets the HWClock using UTC int he `\etc\adjtime` file.
+Here, `-w` tells the `hwclock` to set the hardware time based on the current system time and `-u` tells the hwclock that we are using the UTC. This also sets the HWClock using UTC int he `\etc\adjtime` file.
 
 > If you set a time on the hardware clock wighout mentioning it being UTC / Local, the `/etc/adjtime` will decide this, if this file does not exists, the UTC will be used.
 
-You already now about the `timedatectl` and `date` from the [Localization and globalization chapter](http://linux1st.com/1073-localisation-and-internationalisation.html) so I wont repeat them here.
+You already know about the `timedatectl` and `date` from the [Localization and globalization chapter](http://linux1st.com/1073-localisation-and-internationalisation.html) so I wont repeat them here.
 
 
 ### Time Zones
@@ -89,15 +89,17 @@ But the `/etc/localtime` is a binary file describing your timezone info to the s
 ```
 $ ls -l /etc/localtime 
 lrwxrwxrwx 1 root root 31 Jun 22 11:19 /etc/localtime -> /usr/share/zoneinfo/Asia/Tehran
+$ file /usr/share/zoneinfo/Asia/Tehran
+/usr/share/zoneinfo/Asia/Tehran: timezone data, version 2, no gmt time flags, no std time flags, no leap seconds, 72 transition times, 8 abbreviation chars
 ```
 
-In many cases, this is a soft link to a file located at `/etc/share/zoneinfo/` so it will be updated in case of system update.
+In many cases, this is a soft link to a file located at `/usr/share/zoneinfo/` so it will be updated in case of system update.
 
 ### NTP
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/ntyUBmG8F40" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
-Network Time Protocol is my personal favorite protocol. It is one of the coolest protocols ever if you dive into its details. But unfortunately for LPIC1 you do not need to dive into NTP depths. This protocol uses NTP servers to find out the accurate time shown by best atomic clocks on this planet. One of the most famous severs used by ntp people is `pool.ntp.org`. If you check that website you will see that it is a **pool** of ntp servers and by giving your NTP server the `pool.ntp.org`, it will be redirected to one of the many ntp servers available on that pool.
+**Network Time Protocol**  is my personal favorite protocol. It is one of the coolest protocols ever if you dive into its details. But unfortunately for LPIC1 you do not need to dive into NTP depths. This protocol uses NTP servers to find out the accurate time shown by best atomic clocks on this planet. One of the most famous severs used by ntp people is `pool.ntp.org`. If you check that website you will see that it is a **pool** of ntp servers and by giving your NTP server the `pool.ntp.org`, it will be redirected to one of the many ntp servers available on that pool.
 
 #### ntpdate
 
@@ -114,6 +116,8 @@ After this, we need to set the hwclock to the recently synced system time using 
 
 Instead of manually setting the time each time, you can use a linux service called `ntp` to keep your time using some time servers \(the most famous one is pool.ntp.org\). Install the `ntp` and start the server:
 
+In Debian/Ubuntu: 
+
 ```
 # apt install ntp
 # systemctl start ntp
@@ -128,7 +132,7 @@ root@funlife:~# ntpdate pool.ntp.org
 
 As you can see, now the `ntp` is using the NTP port and `ntpdate` has problems starting up.
 
-Main configuration file of `ntp` is located at /etc/ntp.conf:
+Main configuration file of `ntp` is located at `/etc/ntp.conf`:
 
 ```text
 # cat /etc/ntp.conf
@@ -216,7 +220,7 @@ The `ntpq` queries the ntp service. One famous switch is `-p` \(for Print\) that
 In this output a `*` means that the ntp is using this server as the main reference, `+` means that this is a good server and `-` shows an out of range server which will be neglected.
 
 ### chrony
-Another and a newer NTP protocol implemenation is the `chrony`. Compared to ntpd, this tool provides better results at synchronize time difficult conditions such as intermittent network connections (such as laptops) and congested networks. Chrony is the default NTP client in RedHat 8, SUSE 15 and many other distributions. Another adavn
+Another and a newer NTP protocol implemenation is the `chrony`. Compared to `ntpd` , this tool provides better results at synchronize time difficult conditions such as intermittent network connections (such as laptops) and congested networks. Chrony is the default NTP client in RedHat 8, SUSE 15 and many other distributions. Another adavn
 
 Here is a sample `chrony.conf` file:
 
@@ -340,4 +344,4 @@ $ sudo chronyc makestep
 
 ```
 
-`chrnoyc` connects to the chrony service using TPC or Unix sockets. Therefore, it is possible to use a local `chronyc` to connect to remote `chrony` and issue commands, although in this case you are limited to mainly monitoring commands for security reasons.
+`chrnoyc` connects to the chrony service using TCP or Unix sockets. Therefore, it is possible to use a local `chronyc` to connect to remote `chrony` and issue commands, although in this case you are limited to mainly monitoring commands for security reasons.

--- a/content/1082_system_logging.md
+++ b/content/1082_system_logging.md
@@ -16,26 +16,26 @@ Candidates should be able to configure rsyslog. This objective also includes con
 * Basic configuration of rsyslog.
 * Understanding of standard facilities, priorities and actions.
 * Query the systemd journal.
-* Filter systemd journal data by criteria such as date, service or priority
-* Configure persistent systemd journal storage and journal size
-* Delete old systemd journal data
-* Retrieve systemd journal data from a rescue system or file system copy
-* Understand interaction of rsyslog with systemd-journald
+* Filter systemd journal data by criteria such as date, service or priority.
+* Configure persistent systemd journal storage and journal size.
+* Delete old systemd journal data.
+* Retrieve systemd journal data from a rescue system or file system copy.
+* Understand interaction of rsyslog with systemd-journald.
 * Configuration of logrotate.
 * Awareness of syslog and syslog-ng.
 
 ### Terms and Utilities
 
-* /etc/rsyslog.conf
-* /var/log/
-* logger
-* logrotate
-* /etc/logrotate.conf
-* /etc/logrotate.d/
-* journalctl
-* systemd-cat
-* /etc/systemd/journald.conf
-* /var/log/journal/
+* `/etc/rsyslog.conf`
+* `/var/log/`
+* `logger`
+* `logrotate`
+* `/etc/logrotate.conf`
+* `/etc/logrotate.d/`
+* `journalctl`
+* `systemd-cat`
+* `/etc/systemd/journald.conf`
+* `/var/log/journal/`
 
 ### History
 Logs are an important part of Unix philosophy and design. The Kernel, services, programs and most events (let it be a crash or a login attempt) will generate logs. These logs can be examines / monitored to gain insights about the system and its status. If you watch a Linux guy on a windows machine for 1 hour, you will hear "where are the logs?". 
@@ -137,12 +137,16 @@ user.*				-/var/log/user.log
 *.emerg				:omusrmsg:*
 ```
 
-As you can see facilities can be things like `kern`, `user`, `mail`, `daemon`, `cron`, `auth`, `ntp`, `security`, `console`, `syslog`و ... wehen the *priority* is one of the `emerg`/`panic`, `alert`, `crit`, `err`/`error`, `warn`/`warning`, `notice`, `info` or `debug`. 
+As you can see **facilities** could be things like:
+  > `kern`, `user`, `mail`, `daemon`, `cron`, `auth`, `ntp`, `security`, `console`, `syslog`, ... 
+
+The **priority** could be one of the below:
+  > `emerg`/`panic`, `alert`, `crit`, `err`/`error`, `warn`/`warning`, `notice`, `info` or `debug`. 
 
 On the **action** part we can have things like these:
 
 | action | sample | meaning |
-| :--- | :--- | :--- |
+| :---: | :---: | :--- |
 | filename | /usr/log/logins.log | will write the log to this file |
 | username | jadi | will notify that person on the screen |
 | @ip | @192.168.1.100 | will send this log to this log server and that log server will decide what to do with it based on its configs |
@@ -154,11 +158,41 @@ kern.panic      @192.168.1.100
 *.*             /var/log/messages
 ```
 
-If you log some specific priority, all the **more important** things will be logged too! So if you write `cron.notice /var/log/cron/log`, you are logging the emerg/panic, alert, critical, error, warning and notice logs of the cron category too.
+If you log some specific priority, all the **more important** things will be logged too! So if you write `cron.notice /var/log/cron/cron.log`, you are logging the `emerg/panic`, `alert`, `critical`, `error`, `warning` and `notice` logs of the cron category too.
+
+
+Priority Levels (According to Syslog(3) and logger manpage):
+
+```text
+
+       This determines the importance of the message.  The levels are, in order of decreasing importance:
+
+       emerge      system is unusable
+
+       alert      action must be taken immediately
+
+       crit       critical conditions
+
+       error        error conditions
+
+       warning    warning conditions
+
+       notice     normal, but significant, condition
+
+       info       informational message
+
+       debug      debug-level message
+
+
+       panic      deprecated synonym for emerg
+       error      deprecated synonym for err
+       warn       deprecated synonym for warning
+
+```
 
 > If you need to log ONLY one specific level, add an equal sign \(=\) before the priority like this `local3.=alert /var/log/user.alert.log`.
 
-It is important to know that the binary which logs the _\*kern_ category is a standalone daemon. This daemon is called `klogd` and uses same configuration files. Why? so even after everything is crashed, klogd will be able to log the kernel's crashes ;\)
+It is important to know that the binary which logs the _\*kern_ category is a standalone daemon. This daemon is called `klogd` and uses same configuration files. Why? so even after everything is crashed, `klogd` will be able to log the kernel's crashes ;\).
 
 
 ### logger
@@ -229,7 +263,7 @@ root@debian:# cat /etc/logrotate.d/apt
 These are the meaning of some of these parameters:
 
 | parameter | meaning |
-| :--- | :--- |
+| :---: | :---: |
 | weekly | rotate logs weekly |
 | missingok | it is fine if there is no log for this week |
 | rotate 52 | keep the latest 52 logs and delete the older ones |
@@ -334,7 +368,7 @@ root@debian:~# cat /etc/systemd/journald.conf
 If you run the `journalctl` you will get all the logs... too much. So there are some useful switches:
 
 | Switch | Meaning |
-| --- | --- |
+| :---: | :---: |
 | -r | show in reverse; newer on top |
 | -f | keep showing the tail |
 | -e | show and go to the end |
@@ -344,7 +378,7 @@ If you run the `journalctl` you will get all the logs... too much. So there are 
 | -p | from specific priority, say `-p err` |
 | -u | from a specific systemd unit |
 
-You can also using the `--since` and `--until` to show a specific time range, It is possible to provide time as `YYYY-MM-DD HH:MM:SS` or use things like `yesterday`, `today`, `tomorrow`, `now` or even `--since "10 minutes ago"` which is equals to `--since "-2 minutes"`.
+You can also use the `--since` and `--until` to show a specific time range, It is possible to provide time as `YYYY-MM-DD HH:MM:SS` or use things like `yesterday`, `today`, `tomorrow`, `now` or even `--since "10 minutes ago"` which is equals to `--since "-2 minutes"`.
 
 > If there are too many lines, push `>` to jump to the end (or `<` to go to the beginning)
 
@@ -365,43 +399,43 @@ Jun 30 06:34:48 debian uptime[1022]:  06:34:48 up  1:05,  4 users,  load average
 ## managing storage
 The systemd journals can keep their logs in memeory or write them to the disk or drop all the logs. This is determined by the configurations in `/etc/systemd/journald.conf`. But the default behaviour is as follow:
 
-1. The system checks the `/var/log/journal`. If this exists logs will be saved in a directory inside this. The name of the directory will be decided by looking at `/etc/machine-id`
-2. If the `/var/log/journal` is not there, the logs will be saved at memory at `/run/log/jouranl` and in the directory decided by `/etc/machine-id`.
+1. The system checks the `/var/log/journal`. If this directory, exists logs will be saved in a directory inside this. The name of the directory will be decided by looking at `/etc/machine-id`
+2. If the `/var/log/journal` is not there, the logs will be saved in memory at `/run/log/jouranl` and in the directory decided by `/etc/machine-id`.
 
 But you can overcome these configs by the following sections:
 
 ```
-Storage=volatile # keep the logs in memory
+Storage=volatile     # keep the logs in memory
 Storage=persistent   # keep on disk, if needed create the directories
-Storage=auto  # will write to disk only if the directory exists
-Storage=none # do not keep logs
+Storage=auto         # will write to disk only if the directory exists
+Storage=none         # do not keep logs
 ```
 
 If the logs are being written to disk, these variable will manage the disk usage:
 
 | Variable Name | Usage |
-| ---- | --- | 
+| :----: | --- | 
 | SystemMaxUse | The Maximum disk usage, say 500M. The default is on `10%` |
 | SystemKeepFree | Keep at least this much free, say 1G. The default is 15% |
 | SystemMaxFileSize | Maximum size of each individual file. The default is 1/8 of SystemMaxUse |
 | SystemMaxFiles | Max number of non-currently-active files. The default is 100 |
 
-If you are keeping the logs in the memory, the equivalent variables are `RuntimeMaxUse`, `RuntimeKeepFree`, `RuntimeMaxFileSize`, & `RuntimeMaxFiles`.  
+If you are keeping the logs in **memory**, the equivalent variables are `RuntimeMaxUse`, `RuntimeKeepFree`, `RuntimeMaxFileSize`, & `RuntimeMaxFiles`.  
 
 In case you need to do the clean-up manually (with the help of systemd tools for sure), you can run `journalctl` with these switches:
 
 
  
 | Switch | Usage |
-| ---- | --- | 
+| :----: | --- | 
 | --vacuum-time | clean everything older than this. for example `--vacuum-time=3months` clean anything older than 3 months. You can use `s`, `m`, `h` for seconds, minutes and days and `d`/`days`, `months`, `weeks`/`w` and `years`/`y`. 
 | --vacuum-size | eliminate till logs occupy a specific size; say 1G |
 | --vacuum-files | Only keep this much archive files |
 
 ### checking logs from a recovered system
-If you have a crashed / non booting system, you can still examine its logs; if the files are there. As you known the files are in `/var/log/journal/{mchine-id}` where machine-is id in `/etc/machine-id` of the crashed machine. 
+If you have a crashed / non-booting system, you can still examine its logs; if the files are there. As you know the files are in `/var/log/journal/{mchine-id}` where machine-id is in `/etc/machine-id` of the crashed machine. 
 
-You can move these files to a directory after booting the crashed machine with a live linux or mount its hard on another machine or even examine them in place. The `-D` (or `--directory`) switch of `journalctl` indicated the location of the journal files. So if you your crashed machine id is `ec22e43962c64359b9b25cfa650b025b` and you've mounted its `/var/` under your `/mnt/var/` directory, you can issue this command to read its logs and see what had happened:
+You can move these files to a directory after booting the crashed machine with a live linux or mount its hard on another machine or even examine them in place. The `-D` (or `--directory`) switch of `journalctl` indicates the location of the journal files. So if your crashed machine id is `ec22e43962c64359b9b25cfa650b025b` and you've mounted its `/var/` under your `/mnt/var/` directory, you can issue this command to read its logs and see what had happened:
 
 ```
 journalctl -D=/mnt/var/log/journal/ec22e43962c64359b9b25cfa650b025b/
@@ -415,32 +449,32 @@ Generally logs are saved at `/var/log`. In case of any issue and if you do not k
 But lets have a look at some of the famous logs:
 
 
-##### /var/log/auth.log
+##### `/var/log/auth.log` (in Debian Based)
 
-Authentication processes will log here. Things like cron jobs, failed logins, sudo informations, ...
-##### /var/log/syslog
+Authentication processes will log here. Things like `cron` jobs, failed logins, `sudo` informations, ...
+##### `/var/log/syslog`
 
-A centralized place most of the logs received by rsyslogd if a specific logfile is not provided in `/etc/rsyslog.conf`
-##### /var/log/debug
+A centralized place most of the logs received by `rsyslogd` if a specific logfile is not provided in `/etc/rsyslog.conf`
+##### `/var/log/debug`
 
 Debug information from programs.
 
-##### /var/log/kern.log
+##### `/var/log/kern.log`
 
 Kernel messages.
-##### /var/log/messages
+##### `/var/log/messages`
 
 Informative messages from services. This is also the default place for logs for remote clients.
-##### /var/run/utmp & /var/log/wtmp
+##### `/var/run/utmp` & `/var/log/wtmp`
 
 Successful logins.
-##### /var/log/btmp
+##### `/var/log/btmp`
 
 Failed logins. You can check this to see if anyone is trying to guess your passwords!
-##### /var/log/faillog
+##### `/var/log/faillog`
 
 Failed authentication attempts.
-##### /var/log/lastlog
+##### `/var/log/lastlog`
 Date and time of recent user logins.
 
 ##### Service logs

--- a/content/1083_mail_transfer_agent_mta_basics.md
+++ b/content/1083_mail_transfer_agent_mta_basics.md
@@ -15,22 +15,22 @@ Candidates should be aware of the commonly available MTA programs and be able to
 
 * Create e-mail aliases.
 * Configure e-mail forwarding.
-* Knowledge of commonly available MTA programs \(postfix, sendmail, exim\) \(no configuration\)
+* Knowledge of commonly available MTA programs \(`postfix`, `sendmail`, `exim`\) \(no configuration\)
 
 ### Terms and Utilities
 
-* ~/.forward
+* `~/.forward`
 * sendmail emulation layer commands
-* newaliases
-* mail
-* mailq
-* postfix
-* sendmail
-* exim
+* `newaliases`
+* `mail`
+* `mailq`
+* `postfix`
+* `sendmail`
+* `exim`
 
 ### MTAs
 
-Email is an integral part of many GNU/Linux and Unix systems. Each user do have a mail box and can send / recive email to other local users. This is done via MTAs (Mai Transfer Agents). In other words, MTAs are programs which handle emails in your operating system. They can receive and dispatch emails localy and over the network. There are different options for MTAs. In this section we will do a quick review on them and you will see how you can send emails to other uses (or over the internet) and how you can check your local mails.
+Email is an integral part of many GNU/Linux and Unix systems. Each user do have a mail box and can send / recive email to other local users. This is done via MTAs (Mail Transfer Agents). In other words, MTAs are programs which handle emails in your operating system. They can receive and dispatch emails localy and over the network. There are different options for MTAs. In this section we will do a quick review on them and you will see how you can send emails to other user (or over the internet) and how you can check your local mails.
 
 #### sendmail
 Is one of the oldest options available. It is huge and kind of difficult to configure and not that security oriented. Because of these, few systems use it as default their MTA.
@@ -144,7 +144,7 @@ Each user can create a `.forward` file in her own directory and all mail targete
 
 > You can even put a complete email address like `jadijadi@gmail.com` in your `.forward` file.
 
-It also can send email from the command line or even within your scripts by issuing something like `echo -e "email content" | mail -s "email subject" "example@example.com"`.c
+It also can send email from the command line or even within your scripts by issuing something like `echo -e "email content" | mail -s "email subject" "example@example.com"`.
 
 ### mailq
 


### PR DESCRIPTION
Changes:
- raw text of commands and utilities changed to code block in the below parts:
    - 105-1
    - 105-2
    - 107-1
    - 107-2
    - 108-1
    - 108-2
- changes in 108-1:
    - Fix Some Typo 
    - Add `file /usr/share/zoneinfo/Asia/Tehran` command for getting file type to show its a timezone data file in binary
    - `/etc/share/zoneinfo/` changed to `/usr/share/zoneinfo/` in line 94
    - the `Network Time Protocol` has been bolded in line 102
- Changes in 108-2:
    - Fix Some Typo 
    - add a period to the end of the 19..23 lines.
    - Line 140 apart into two lines to be more clear 
    - in line 145, align the table body to the center (the action table)
    - Add Priority Levels (According to Syslog(3) and logger manpage): in line 164
    - And fix some other minor changes


