### PR TITLE
Update: content/1093_basic_network_troubleshooting.md

### DIFF
--- a/content/1093_basic_network_troubleshooting.md
+++ b/content/1093_basic_network_troubleshooting.md
@@ -15,24 +15,24 @@ Candidates should be able to troubleshoot networking issues on client hosts.
 * Manually configure network interfaces, including viewing and changing the configuration of network interfaces using iproute2.
 * Manually configure routing, including viewing and changing routing tables and setting the default route using iproute2.
 * Debug problems associated with the network configuration.
-* Awareness of legacy net-tools commands.
+* Awareness of legacy `net-tools` commands.
 
 
 ### Terms and Utilities
 
-* ip
-* hostname
-* ss
-* ping
-* ping6
-* traceroute
-* traceroute6
-* tracepath
-* tracepath6
-* netcat
-* ifconifg
-* netstat
-* route
+* `ip`
+* `hostname`
+* `ss`
+* `ping`
+* `ping6`
+* `traceroute`
+* `traceroute6`
+* `tracepath`
+* `tracepath6`
+* `netcat`
+* `ifconifg`
+* `netstat`
+* `route`
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/sAzkN5P2-0E?si=P1r5KgfEvit_BMFW" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
@@ -60,6 +60,9 @@ As you already know, `ifconfig` and `ip` commands can be used to check the IP ad
        valid_lft 254836sec preferred_lft 254836sec
     inet6 fe80::8ea9:82ff:fe7b:8906/64 scope link
        valid_lft forever preferred_lft forever
+[jadi@debian ~]$ 
+[jadi@debian ~]$ 
+[jadi@debian ~]$ 
 [jadi@debian ~]$ ifconfig
 enp0s25   Link encap:Ethernet  HWaddr f0:de:f1:62:c5:73  
           inet addr:192.168.1.35  Bcast:192.168.1.255  Mask:255.255.255.0
@@ -154,7 +157,7 @@ rtt min/avg/max/mdev = 3.039/3.174/3.310/0.146 ms
 What is going on here? Let's see, what clues do I have:
 1) I can reach the gateway.
 2) when asking for the Internet, my computer does not know what to do.
-In this case the **default gateway** is missing: the computer does not know what to do if a packet is outside its network mask. You know that we can set the default gateway using the /etc/network/interfaces config file, but there is also a `route` (or the newer `ip route` subcommand) to show and change the routing configurations on the fly.
+In this case the **default gateway** is missing: the computer does not know what to do if a packet is outside its network mask. You know that we can set the default gateway using the `/etc/network/interfaces` config file, but there is also a `route` (or the newer `ip route` subcommand) to show and change the routing configurations on the fly.
 
 > Routes added or changed via `ip route` (or `route`) will be lost after a reboot! Permanent configurations should come from configuration files.
 
@@ -273,7 +276,7 @@ tcp               LISTEN             0                  128                     
 
 #### netcat
 
-The nc \(or netcat\) utility is used for just about anything under the sun involving TCP, UDP, or UNIX-domain sockets. It can open TCP connections, send UDP packets, listen on arbitrary TCP and UDP ports, do port scanning, and deal with both IPv4 and IPv6. Unlike telnet, nc can be used easily in the scripts and separates error messages onto standard error instead of sending them to standard output, as telnet does with some. This is a very capable command, and it is enough for you to be familiar with its general concept.
+The `nc` \(or netcat\) utility is used for just about anything under the sun involving TCP, UDP, or UNIX-domain sockets. It can open TCP connections, send UDP packets, listen on arbitrary TCP and UDP ports, do port scanning, and deal with both IPv4 and IPv6. Unlike `telnet`, `nc` can be used easily in the scripts and separates error messages onto standard error instead of sending them to standard output, as telnet does with some. This is a very capable command, and it is enough for you to be familiar with its general concept.
 
 Here I'm creating a tcp listener on port 1337:
 

--- a/content/1094_configure_client_side_dns.md
+++ b/content/1094_configure_client_side_dns.md
@@ -20,12 +20,14 @@ Candidates should be able to configure DNS on a client host.
 
 ### Terms and Utilities
 
-* /etc/hosts
-* /etc/resolv.conf
-* /etc/nsswitch.conf
-* host
-* dig
-* getent
+* `/etc/hosts`
+* `/etc/resolv.conf`
+* `/etc/nsswitch.conf`
+* `host`
+* `dig`
+* `getent`
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/wUDhmSpr3lg?si=O1LCyXq_L4LmLn39" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
 ### DNS
 
@@ -90,9 +92,9 @@ x.org.            1625    IN    A    131.252.210.176
 ;; MSG SIZE  rcvd: 50
 ```
 
-As you can see, `dig` did an **ip lookup** for `x.org` and told me that its IP is 131.252.210.176. The `1625` is called the TTL or _Time To Live_ and show how many seconds this answer will be considered valid in chache. This command also tells us which server is used to query the answer \(last 4 lines\) and when and how long it took.
+As you can see, `dig` did an **ip lookup** for `x.org` and told me that its IP is 131.252.210.176. The `1625` is called the **TTL** or _Time To Live_ and show how many seconds this answer will be considered valid in cache. This command also tells us which server is used to query the answer \(last 4 lines\) and when and how long it took.
 
-There is also a way to tell `dig` command what server it should use as the DNS:
+There is also a way to tell `dig` command what server it should use as the DNS vi `@<DNS-SERVER>`:
 
 ```text
 $ dig @8.8.8.8 google.com
@@ -128,9 +130,9 @@ google.com.        112    IN    A    173.194.32.142
 ;; MSG SIZE  rcvd: 215
 ```
 
-Here I have asked dig to use `8.8.8.8` as its DNS and query `google.com`. You can see that I've got more than 1 answer \(actually much more than 1 answer\). My computer can randomly contact any of those IPs to reach the `google.com`. In other words, google.com is using more than 1 server/IP and `8.8.8.8` provides all of them when queried for that domain.
+Here I have asked dig to use `8.8.8.8` as its DNS and query `google.com`. You can see that I've got more than one answer \(actually much more than one answer\). My computer can randomly contact any of those IPs to reach the `google.com`. In other words, google.com is using more than one server/IP and `8.8.8.8` provides all of them when queried for that domain.
 
-### /etc/hosts
+### `/etc/hosts`
 
 This file contains IP addresses and their correspondive names. This is kind of an static name resolution on your computer. Let's have a look:
 
@@ -283,6 +285,8 @@ $ getent hosts
 127.0.0.1       frctlmeth
 ```
 
-### systemd-resolved
+### `systemd-resolved`
 
 It should be noted that the `systemd` provides a DNS called `systemd-resolved`. It listens for DNS requests on `127.0.0.53` and answers back after consulgint the `/etc/systemd/resolv.conf` or `/etc/resolv.conf`.
+
+Read more [Here](https://wiki.archlinux.org/title/Systemd-resolved) about `systemd-resolved`.


### PR DESCRIPTION
Changes in 109-3:
- Convert terms and utilities to code block 
- Add three Enter to be clear the output of `ifconfig` in line 63
- Changed /etc/network/interfaces into `/etc/network/interfaces` in line 160

changes in 109-4:
- Add YouTube Video Link 
- Convert utilities to code block
- TTL Bolded in line 95 
- Add Link to read more about systemd
