### PR TITLE
1045: Fix typo (chmod)

### DIFF
--- a/content/1045_manage_file_permissions_and_ownership.md
+++ b/content/1045_manage_file_permissions_and_ownership.md
@@ -289,6 +289,6 @@ $ umask
 0177
 ```
 
-> Note how I used `u=rw,g=,o=` to tell `umask` or `chomod` what I exactly wanted from it.
+> Note how I used `u=rw,g=,o=` to tell `umask` or `chmod` what I exactly wanted from it.
 
 


### PR DESCRIPTION
Fixed typo in **chmod** name