### PR TITLE
Fix typo in 1038_perform_basic_file_editing_operations_using_vi.md file

### DIFF
--- a/content/1038_perform_basic_file_editing_operations_using_vi.md
+++ b/content/1038_perform_basic_file_editing_operations_using_vi.md
@@ -145,7 +145,7 @@ These command during the _command mode_ will help you enter, edit, replace and t
 | o | open a new line below the cursor and go to the insert mode |
 | O | open a new line above the cursor and go to the insert mode |
 | c | clear to a location and go to the insert mode the replace till there and then normal insert \(`cw` will overwrite the current word\) |
-| d | delete. you can mix with w \(`dw`\) to delete a word. Same as cw but dw does not to to the insert mode |
+| d | delete. you can mix with w \(`dw`\) to delete a word. Same as cw but dw does not go to the insert mode |
 | dd | Delete the current line |
 | x | Delete character at the position of the cursor |
 | p | Paste the last deleted text after the cursor |

--- a/content/1042_maintain_the_integrity_of_filesystems.md
+++ b/content/1042_maintain_the_integrity_of_filesystems.md
@@ -198,7 +198,7 @@ fsck from util-linux 2.25.1
 Some version do have a `-a` for automatic fixing all found issues but its not recommended. 
 ### e2fsck
 
-`e2fsck` is used to check the ext2/ext3/ext4 family of file systems.  For ext3 and ext4 file systems that use a `journal`, if the system has been shutdown uncleanly without any errors,normally, after replaying the committed transactions  in the journal, the file system should be marked as clean. Hence, forfile systems that use **journaling** , e2fsck will normally replay the journal and exit, unless its superblock indicates that further checking is required.
+`e2fsck` is used to check the ext2/ext3/ext4 family of file systems.  For ext3 and ext4 file systems that use a `journal`, if the system has been shutdown uncleanly without any errors,normally, after replaying the committed transactions  in the journal, the file system should be marked as clean. Hence, for file systems that use **journaling** , e2fsck will normally replay the journal and exit, unless its superblock indicates that further checking is required.
 
 device is a block device (e.g., `/dev/sdc1`) or file containing the file system.
 


### PR DESCRIPTION
found a little typo and fixed it in:
1038_perform_basic_file_editing_operations_using_vi.md file
1042_maintain_the_integrity_of_filesystems.md